### PR TITLE
Abstract systemd and networkmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.swp
+__pycache__
+env/
+pacparser/

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,5 @@ uninstall:
 clean:
 	rm -rf env
 	rm -rf pacparser
+	rm -rf __pycache__
+

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,15 @@ install-service: check-prev-proxies
 
 	install -D -m 755 trigger-pac4cli $(DESTDIR)/etc/NetworkManager/dispatcher.d/trigger-pac4cli
 	install -D -m 755 pac4cli.sh $(DESTDIR)/etc/profile.d/pac4cli-proxy.sh
+	install -D -m 644 pac4cli.config $(DESTDIR)/etc/pac4cli/pac4cli.config
 
 install-bin:
 	install -D -m 755 main.py $(DESTDIR)$(bindir)/pac4cli
 	@sed -i -e '1s+@PYTHON@+'$(PYTHON)'+' $(DESTDIR)$(bindir)/pac4cli
 
 	install -D -m 644 pac4cli.py $(DESTDIR)$(pythonsitedir)/pac4cli.py
+	install -D -m 644 wpad.py $(DESTDIR)$(pythonsitedir)/wpad.py
+	install -D -m 644 servicemanager.py $(DESTDIR)$(pythonsitedir)/servicemanager.py
 
 install: install-bin install-service
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ import platform
 import pacparser
 import signal
 
-
 import configparser
 
 parser= ArgumentParser(description="""

--- a/main.py
+++ b/main.py
@@ -8,17 +8,17 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.web.client import Agent
 
 from wpad import WPAD
+import servicemanager
 
 from argparse import ArgumentParser
+
+import platform
 
 import pacparser
 import signal
 
-import systemd.daemon
-import systemd.journal
 
 import configparser
-import platform
 
 parser= ArgumentParser(description="""
 Run a simple HTTP proxy on localhost that uses a wpad.dat to decide
@@ -45,8 +45,8 @@ def start_server(port, reactor):
     factory.protocol.requestFactory = WPADProxyRequest
 
     yield reactor.listenTCP(port, factory, interface="127.0.0.1")
-
-    systemd.daemon.notify(systemd.daemon.Notification.READY)
+    
+    servicemanager.notify_ready();
 
 @inlineCallbacks
 def get_possible_configuration_locations():
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     log_level_name = os.environ.get('LOG_LEVEL', args.loglevel)
     log_level = getattr(logging, log_level_name.upper(), logging.INFO)
     if args.systemd:
-        log_handler = systemd.journal.JournaldLogHandler()
+        log_handler = servicemanager.getLogHandler()
     else:
         log_handler = logging.StreamHandler()
     logger.setLevel(log_level)

--- a/pac4cli.config
+++ b/pac4cli.config
@@ -1,0 +1,3 @@
+[wpad]
+# Provide your own PAC file url. This will override whatever is used by NetworkManager if present.
+#url=http://wpad.file.url

--- a/servicemanager.py
+++ b/servicemanager.py
@@ -1,0 +1,16 @@
+import platform
+import logging
+
+if 'Linux' == platform.system():
+    import systemd.daemon
+    import systemd.journal
+
+def notify_ready():
+    if 'Linux' == platform.system():
+        systemd.daemon.notify(systemd.daemon.Notification.READY)
+
+def getLogHandler():
+    if 'Linux' == platform.system():
+        return systemd.journal.JournaldLogHander()
+    else:
+        return logging.NullHandler()

--- a/wpad.py
+++ b/wpad.py
@@ -1,0 +1,83 @@
+import platform
+import configparser
+
+import logging
+
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
+from twisted.internet import defer
+
+if 'Linux' == platform.system():
+    import txdbus.client
+    # work around txdbus assuming python 2
+    txdbus.client.basestring = str
+
+class WPAD:
+    def __init__(self, reactor, config_file):
+        self.reactor = reactor
+        self.config_file = config_file
+    
+    def set_logger( self, logger ):
+        self.logger = logger
+
+
+    @inlineCallbacks
+    def get_dhcp_domains(self):
+        res = []
+        if 'Linux' != platform.system():
+            if self.logger:
+                self.logger.info("No NetworkManager available.") 
+            return res
+
+        dbus = yield txdbus.client.connect(self.reactor, 'system')
+        nm = yield dbus.getRemoteObject('org.freedesktop.NetworkManager',
+                                       '/org/freedesktop/NetworkManager')
+        active_connection_paths = yield nm.callRemote('Get',
+                'org.freedesktop.NetworkManager', 'ActiveConnections')
+
+        for path in active_connection_paths:
+            conn = yield dbus.getRemoteObject('org.freedesktop.NetworkManager',
+                                              path)
+            config_path = yield conn.callRemote('Get',
+                        'org.freedesktop.NetworkManager.Connection.Active', 'Ip4Config')
+            config = yield dbus.getRemoteObject('org.freedesktop.NetworkManager',
+                                                config_path)
+            domains = yield config.callRemote('Get',
+                    'org.freedesktop.NetworkManager.IP4Config', 'Domains')
+            res.extend(domains)
+
+        return res
+
+    @inlineCallbacks
+    def get_config_wpad_url(self, config_file):
+        if config_file:
+            if self.logger:
+                self.logger.info("Found config file '%s'", config_file)
+            config = configparser.SafeConfigParser()
+            config.read(config_file)
+            try:
+                url = yield config.get('wpad', 'url')
+                if self.logger:
+                    self.logger.info("Read wpad url: %s", url)
+                return url
+            except configparser.NoOptionError:
+                if self.logger:
+                    self.logger.info("No wpad url specified")
+                yield defer.succeed(None)
+        else:
+            yield defer.succeed(None)
+
+    @inlineCallbacks
+    def getUrls(self):
+        wpad_url = yield self.get_config_wpad_url(self.config_file)
+        if wpad_url is not None:
+            return [ wpad_url ]
+        else:
+            if self.logger:
+                self.logger.info("Trying to get wpad url from NetworkManager...")
+            domains = yield self.get_dhcp_domains()
+            return [
+                "http://wpad.{}/wpad.dat".format(domain)
+                for domain in domains
+            ]
+

--- a/wpad.py
+++ b/wpad.py
@@ -2,6 +2,7 @@ import platform
 import configparser
 
 import logging
+import os
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
@@ -50,7 +51,7 @@ class WPAD:
 
     @inlineCallbacks
     def get_config_wpad_url(self, config_file):
-        if config_file:
+        if config_file and os.path.isfile(config_file):
             if self.logger:
                 self.logger.info("Found config file '%s'", config_file)
             config = configparser.SafeConfigParser()


### PR DESCRIPTION
This is a first step in supporting mac.
In this branch:
- systemd is abstracted out from the main script.
- communicating with NetworkManager through dbus is abstracted out from the main script.
- imports and usage of systemd and dbus are guarded with a check for 'Linux' platform.

The main target of this change is to be able to run `python main.py ...` on mac without issues. Unfortunately I don't own a mac. So, it's not tested on a mac yet.