### PR TITLE
Fixes for systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/tkluck/pac4cli.git
 
 Package: pac4cli
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pacparser, python3-twisted, python3-openssl, python3-service-identity, python3-txdbus, python3-systemd-cython
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pacparser, python3-twisted, python3-openssl, python3-service-identity, python3-txdbus
 Description: Proxy-auto-discovery for command line applications
  On many corporate networks, applications need proxy-auto-discovery to know
  whether a certain URL is accessed either directly or through a web proxy.

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/tkluck/pac4cli.git
 
 Package: pac4cli
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pacparser, python3-twisted, python3-openssl, python3-service-identity, python3-txdbus
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pacparser, python3-twisted, python3-openssl, python3-service-identity, python3-txdbus, python3-systemd
 Description: Proxy-auto-discovery for command line applications
  On many corporate networks, applications need proxy-auto-discovery to know
  whether a certain URL is accessed either directly or through a web proxy.

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     log_level_name = os.environ.get('LOG_LEVEL', args.loglevel)
     log_level = getattr(logging, log_level_name.upper(), logging.INFO)
     if args.systemd:
-        log_handler = servicemanager.getLogHandler()
+        log_handler = servicemanager.LogHandler()
     else:
         log_handler = logging.StreamHandler()
     logger.setLevel(log_level)

--- a/servicemanager.py
+++ b/servicemanager.py
@@ -1,16 +1,18 @@
 import platform
 import logging
 
+LogHandler = logging.NullHandler
+def notify_ready():
+    pass
+
 if 'Linux' == platform.system():
     import systemd.daemon
     import systemd.journal
-
-def notify_ready():
-    if 'Linux' == platform.system():
-        systemd.daemon.notify(systemd.daemon.Notification.READY)
-
-def getLogHandler():
-    if 'Linux' == platform.system():
-        return systemd.journal.JournaldLogHandler()
-    else:
-        return logging.NullHandler()
+    if hasattr(systemd.journal, 'JournalHandler'):       # official bindings
+        LogHandler = systemd.journal.JournalHandler
+        def notify_ready():
+            systemd.daemon.notify("READY=1")
+    elif hasattr(systemd.journal, 'JournaldLogHandler'): # mosquito bindings
+        LogHandler = systemd.journal.JournaldLogHandler
+        def notify_ready():
+            systemd.daemon.notify(systemd.daemon.Notification.READY)

--- a/servicemanager.py
+++ b/servicemanager.py
@@ -11,6 +11,6 @@ def notify_ready():
 
 def getLogHandler():
     if 'Linux' == platform.system():
-        return systemd.journal.JournaldLogHander()
+        return systemd.journal.JournaldLogHandler()
     else:
         return logging.NullHandler()


### PR DESCRIPTION
This fixes a small typo, and it also adds support for the 'official' python bindings for systemd. I don't want to continue supporting two backends indefinitely, but for now, this is the quickest way to ensure this can work in Ubuntu.