### PR TITLE
Support older twisted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ install-bin:
 	install -D -m 644 pac4cli.py $(DESTDIR)$(pythonsitedir)/pac4cli.py
 	install -D -m 644 wpad.py $(DESTDIR)$(pythonsitedir)/wpad.py
 	install -D -m 644 servicemanager.py $(DESTDIR)$(pythonsitedir)/servicemanager.py
+	install -D -m 644 portforward.py $(DESTDIR)$(pythonsitedir)/portforward.py
 
 install: install-bin install-service
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -20,3 +20,37 @@ License: GPL-3+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+Files: portforward.py
+Copyright: 2001-2017 Allen Short, Amber Hawkie Brown, Andrew Bennetts, Andy
+Gayton, Antoine Pitrou, Apple Computer, Inc., Ashwini Oruganti, Benjamin
+Bruheim, Bob Ippolito, Canonical Limited, Christopher Armstrong, David Reid,
+Divmod Inc., Donovan Preston, Eric Mangold, Eyal Lotem, Google Inc., Hybrid
+Logic Ltd., Hynek Schlawack, Itamar Turner-Trauring, James Knight, Jason A.
+Mobarak, Jean-Paul Calderone, Jessica McKellar, Jonathan D. Simms, Jonathan
+Jacobs, Jonathan Lange, Julian Berman, Jürgen Hermann, Kevin Horn, Kevin
+Turner, Laurens Van Houtven, Mary Gardiner, Massachusetts Institute of
+Technology, Matthew Lefkowitz, Moshe Zadka, Paul Swartz, Pavel Pergamenshchik,
+Rackspace, US Inc., Ralph Meijer, Richard Wall, Sean Riley, Software Freedom
+Conservancy, Tavendo GmbH, Thijs Triemstra, Thomas Herve, Timothy Allen, Tom
+Prince, Travis B. Hartwell, and others that have contributed code to the public
+domain.
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pac4cli.py
+++ b/pac4cli.py
@@ -12,7 +12,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
 
 from twisted.python.compat import urllib_parse
 
-from twisted.protocols import portforward
+import portforward
 
 logger = logging.getLogger('pac4cli')
 

--- a/portforward.py
+++ b/portforward.py
@@ -1,0 +1,99 @@
+
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
+"""
+A simple port forwarder.
+"""
+
+# Twisted imports
+from twisted.internet import protocol
+from twisted.python import log
+
+class Proxy(protocol.Protocol):
+    noisy = True
+
+    peer = None
+
+    def setPeer(self, peer):
+        self.peer = peer
+
+
+    def connectionLost(self, reason):
+        if self.peer is not None:
+            self.peer.transport.loseConnection()
+            self.peer = None
+        elif self.noisy:
+            log.msg("Unable to connect to peer: %s" % (reason,))
+
+
+    def dataReceived(self, data):
+        self.peer.transport.write(data)
+
+
+
+class ProxyClient(Proxy):
+    def connectionMade(self):
+        self.peer.setPeer(self)
+
+        # Wire this and the peer transport together to enable
+        # flow control (this stops connections from filling
+        # this proxy memory when one side produces data at a
+        # higher rate than the other can consume).
+        self.transport.registerProducer(self.peer.transport, True)
+        self.peer.transport.registerProducer(self.transport, True)
+
+        # We're connected, everybody can read to their hearts content.
+        self.peer.transport.resumeProducing()
+
+
+
+class ProxyClientFactory(protocol.ClientFactory):
+
+    protocol = ProxyClient
+
+    def setServer(self, server):
+        self.server = server
+
+
+    def buildProtocol(self, *args, **kw):
+        prot = protocol.ClientFactory.buildProtocol(self, *args, **kw)
+        prot.setPeer(self.server)
+        return prot
+
+
+    def clientConnectionFailed(self, connector, reason):
+        self.server.transport.loseConnection()
+
+
+
+class ProxyServer(Proxy):
+
+    clientProtocolFactory = ProxyClientFactory
+    reactor = None
+
+    def connectionMade(self):
+        # Don't read anything from the connecting client until we have
+        # somewhere to send it to.
+        self.transport.pauseProducing()
+
+        client = self.clientProtocolFactory()
+        client.setServer(self)
+
+        if self.reactor is None:
+            from twisted.internet import reactor
+            self.reactor = reactor
+        self.reactor.connectTCP(self.factory.host, self.factory.port, client)
+
+
+
+class ProxyFactory(protocol.Factory):
+    """
+    Factory for port forwarder.
+    """
+
+    protocol = ProxyServer
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port


### PR DESCRIPTION
In Twisted 16.0.0 (which is on the LTS version of Ubuntu; i.e. what people in corporate environments would likely be running), `portforward.py` isn't included yet. Let's ship it as part of our bundle.