### PR TITLE
launchd.plist: use http://host:port/ format for proxy environment variables

### DIFF
--- a/launchd/agent.pac4cli.plist
+++ b/launchd/agent.pac4cli.plist
@@ -10,13 +10,13 @@
 		<string>/bin/launchctl</string>
 		<string>setenv</string>
 		<string>http_proxy</string>
-		<string>localhost:3128</string>
+		<string>http://localhost:3128/</string>
 		<string>https_proxy</string>
-		<string>localhost:3128</string>
+		<string>http://localhost:3128/</string>
 		<string>HTTP_PROXY</string>
-		<string>localhost:3128</string>
+		<string>http://localhost:3128/</string>
 		<string>HTTPS_PROXY</string>
-		<string>localhost:3128</string>
+		<string>http://localhost:3128/</string>
 		<string>_JAVA_OPTIONS</string>
 		<string>-Dhttp.proxyHost=localhost -Dhttp.proxyPort=3128 -Dhttps.proxyHost=localhost -Dhttps.proxyPort=3128</string>
 	</array>


### PR DESCRIPTION
Hi,

Some utilities don't like to have only "host:port".

E.g., with offlineimap:
  [Errno url error] invalid proxy for https: 'localhost:3128' ...

Using the http://localhost:3128/ makes it work with those utilities.

Regards,
Luciano Rocha