### PR TITLE
wpad DHCP properties

### DIFF
--- a/pac4cli.service
+++ b/pac4cli.service
@@ -3,7 +3,7 @@ Description=PAC autoconfigured proxy for use through http_proxy= environment var
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/pac4cli -p 3128 --systemd --loglevel warn
+ExecStart=/usr/local/bin/pac4cli -p 3128 --systemd --config /etc/pac4cli/pac4cli.config --loglevel warn
 Restart=always
 
 [Install]


### PR DESCRIPTION
Timo,

Thanks so much for writing this program!  It's just what I was looking for.

My corporate network requires a proxy, which is automatically advertised to Windows boxes.  However, it doesn't use DNS (via a machine named "wpad"), but it uses a "wpad" property returned by the DHCP servers.  I extended pac4cli to use this method as well, by querying NetworkManager for the DHCP properties.  Pac4cli goes with the first "wpad" property it finds on an active interface.  If there are none, it falls back to DNS queries, as before.  I gave the DHCP method higher priority, as described by https://en.wikipedia.org/wiki/Web_Proxy_Auto-Discovery_Protocol.

I also noticed that the pac4cli.service file doesn't automatically use the installed config file.  So I fixed that as well.

If you'd consider merging these changes, especially the DHCP support, I'd appreciate it.  You'll want to take a close look at the code, though... I'm a newbie with python, so I may have made some mistakes.  I can say that the changes work on my corporate network, and on a proxyless network.  Slick!

BTW, your PPA doesn't seem to have any Bionic (18.04) builds yet.  But the Artful (17.10) builds seem to work fine on Bionic.

Thanks much,
Brian