### PR TITLE
CircleCI continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run: sudo apt-get install libsystemd-dev
+      - run: make check
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Proxy-auto-discovery for command line applications (pac4cli)
 
+![CircleCI](https://img.shields.io/circleci/project/github/tkluck/pac4cli.svg)
+
 ### Introduction
 
 On many corporate networks, applications need

--- a/testrun.sh
+++ b/testrun.sh
@@ -7,7 +7,7 @@ env/bin/python main.py -p $PORT1  -F DIRECT &
 PID1=$!
 env/bin/python main.py -p $PORT2 -F "PROXY localhost:$PORT1" &
 PID2=$!
-sleep 0.3
+sleep 5
 
 (
     http_proxy=localhost:$PORT1 curl http://booking.com &&


### PR DESCRIPTION
If we're getting more pull requests, it starts making sense to have continuous integration. I've looked into CircleCI, Travis and Appveyor:

 - Travis uses a relatively old Ubuntu image (14.04) that doesn't have libsystemd packaged.
 - Appveyor has linux support still in closed beta.
 - CircleCI uses any docker image, and in practice offers convenient versions of Debian with `libsystemd-dev` in the repository.

I would have preferred Ubuntu because that's what I run locally as well, but Debian is close.

In the container, the proxy takes a bit longer to come up, which I've reflected in a longer delay in `testrun.sh`.

Possible future improvements:
 - The CircleCI documentation mentions options for caching dependency downloads;
 - Roll a custom docker image with `libsystemd-dev` pre-installed.