### PR TITLE
make: target 'pacparser' isn't phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ pythonsitedir = "$(shell $(PYTHON) -c "from distutils.sysconfig import get_pytho
 default:
 	@echo Nothing to build\; run make install.
 
-.PHONY: pacparser
 pacparser:
 	curl -L https://github.com/pacparser/pacparser/archive/1.3.7.tar.gz | tar -xz
 	mv pacparser-1.3.7 pacparser


### PR DESCRIPTION
If the 'pacparser' target is marked as 'PHONY', then it gets downloaded
every time 'make install' is called. And it will error out after the 2nd
call. (The 2nd download will be renamed to pacparser/pacparser-1.3.7 and
the 3rd will complain that 'pacparser/pacparser-1.3.7' isn't empty.)

So this commits removes the PHONY attribute from that target. Tested on OSX.