### PR TITLE
Don't install `make check` requirements by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ run: env
 
 .PHONY: check
 check: env
+	env/bin/pip install -r requirements-check.txt
 	env/bin/python test/runtests.py
 
 .PHONY: check-prev-proxies

--- a/requirements-check.txt
+++ b/requirements-check.txt
@@ -1,0 +1,3 @@
+pygobject
+python-dbusmock
+plumbum

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@ twisted
 pyOpenSSL
 service_identity
 dbus-python
-pygobject
-python-dbusmock
-plumbum


### PR DESCRIPTION
The checks currently rely on linux-only dbus.