### PR TITLE
Feature/listen on ipv6 interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__
 env/
 pacparser/
+build/
+dist/
+pac4cli.egg-info/

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -15,13 +15,16 @@ from .wpad import WPAD, install_network_state_changed_callback
 from .pac4cli import WPADProxyRequest
 from . import servicemanager
 
+import socket
+import ipaddress
+
 
 parser= ArgumentParser(description="""
 Run a simple HTTP proxy on localhost that uses a wpad.dat to decide
 how to connect to the actual server.
 """)
 parser.add_argument("-c", "--config", type=str)
-parser.add_argument("-b", "--bind", type=str, metavar="ADDRESS", default="127.0.0.1")
+parser.add_argument("-b", "--bind", type=str, metavar="ADDRESS", default="localhost")
 parser.add_argument("-p", "--port", type=int, metavar="PORT")
 parser.add_argument("-F", "--force-proxy", type=str, metavar="PROXY STRING")
 parser.add_argument("--loglevel", type=str, default="info", metavar="LEVEL")
@@ -35,9 +38,30 @@ def start_server(interface, port, reactor):
     factory.protocol = proxy.Proxy
     factory.protocol.requestFactory = WPADProxyRequest
 
-    yield reactor.listenTCP(port, factory, interface=interface)
+    interface_ips = resolve(interface)
+    print( interface_ips )
+    for interface_ip in interface_ips:
+        logger.info("Binding to interface: '%s'" % interface_ip)
+        yield reactor.listenTCP(port, factory, interface=interface_ip)
     
     servicemanager.notify_ready();
+
+def resolve(interface):
+    logger.info("resolving interface: %s" % interface)
+    addr = []
+    try:
+        ip = ipaddress.ip_address(interface)
+        logger.info("%s => %s" % (interface,ip))
+        addr.append(ip.exploded)
+    except ValueError as e:
+        # It is an invalid ip address, let's see if it is a hostname
+        results = socket.getaddrinfo(interface, None, proto=socket.IPPROTO_TCP)
+        for entry in results:
+            ip = entry[4][0]
+            ip = ipaddress.ip_address(ip)
+            logger.info("%s => %s" % (interface, ip.exploded))
+            addr.append(ip.exploded)
+    return addr
 
 @inlineCallbacks
 def get_possible_configuration_locations():


### PR DESCRIPTION
Accept hostnames in --bind. This will result in getting the IPv4 and IPv6 interfaces for that hostname (if any). And we listen on all interfaces.

ex.:
`env/bin/python -m pac4cli -p 3128 --config /etc/pac4cli/pac4cli.config --loglevel info --bind localhost`

This will listen on both `127.0.0.1` and `::1`

This should solve #44 