### PR TITLE
systemd config: wait for NetworkManager

### DIFF
--- a/pac4cli.service
+++ b/pac4cli.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PAC autoconfigured proxy for use through http_proxy= environment variables
-After=network.target
+Requires=NetworkManager.service
 
 [Service]
 ExecStart=/usr/local/bin/pac4cli -p 3128 --systemd --config /etc/pac4cli/pac4cli.config --loglevel warn


### PR DESCRIPTION
Before this commit, we would start more-or-less simultaneously with NetworkManager, as we were also part of the network target. This leads to race conditions, and we'll terminate with an error if we cannot talk to NetworkManager's dbus interface.

This was an issue for me at the reboot immediately following the upgrade to Ubuntu 18.10, but I'm not sure it's related to that.

In any case, it's probably better not to start unless NetworkManager is up.

@kdehairy I haven't been able to test this in the archlinux container yet, but I'll try that.