### PR TITLE
debian packaging: remove obsolete configuration file

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -26,6 +26,12 @@ start_service() {
 
 case "$1" in
     configure)
+        # this old configuration file breaks pac4cli startup
+        # because it sends SIGHUPs that we don't handle anymore
+        # since e2f264aa5adf7f4a3c2d3ed2. Technically, we shouldn't
+        # just remove this but check for local modifications, but
+        # that's sufficiently unlikelye that I'll just go with this.
+        rm -f /etc/NetworkManager/dispatcher.d/trigger-pac4cli
         start_service
     ;;
 


### PR DESCRIPTION
This configuration file is not part of new installs any more since 6dfe776b4eb60bd151066783ffcd8b674ac67340, but debian leaves old configuration files around unless the user purges them. It seems to do that even if there's no local modifications. (At least I don't remember local modifications on my system.)

Having this configuration file around is dangerous since e2f264aa5adf7f4a, as it will send a SIGHUP to a process that doesn't expect it.

I don't rememember this having given actual trouble until my upgrade to Ubuntu 18.10, and I could speculate that it has some change in behaviour for `systemctl kill` and how it deals with the parent `pac4cli` process and the actual daemon `python3 -m pac4cli`. This is wild speculation though.

I already pushed this commit to launchpad for the daily builds.

Trying to debug this was a perfect storm -- there's nothing in the systemd journal about why a process exits, and we also don't log the signals ourselves. Moreover, I discarded the SIGHUP hypothesis early on after checking the hooks under `/etc/network`, forgetting about fe581c7568e3f3becee82bfbc0b058364dac63df.