### PR TITLE
Systemd after networkmanager

### DIFF
--- a/pac4cli.service
+++ b/pac4cli.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=PAC autoconfigured proxy for use through http_proxy= environment variables
-After=network.target
+Requires=NetworkManager.service
+After=NetworkManager.service
 
 [Service]
 ExecStart=/usr/local/bin/pac4cli -p 3128 --systemd --config /etc/pac4cli/pac4cli.config --loglevel warn

--- a/pac4cli.service
+++ b/pac4cli.service
@@ -4,8 +4,10 @@ Requires=NetworkManager.service
 After=NetworkManager.service
 
 [Service]
+Type=notify
 ExecStart=/usr/local/bin/pac4cli -p 3128 --systemd --config /etc/pac4cli/pac4cli.config --loglevel warn
 Restart=always
+NotifyAccess=all
 
 [Install]
 WantedBy=network.target

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -111,8 +111,6 @@ def main(args):
         WPADProxyRequest.force_direct = 'DIRECT' # direct, until we have a configuration
         if args.force_proxy:
             WPADProxyRequest.force_proxy = args.force_proxy
-        else:
-            yield updateWPAD()
 
         try:
             yield install_network_state_changed_callback(reactor, updateWPAD)
@@ -126,7 +124,9 @@ def main(args):
         force_proxy_message = ", sending all traffic through %s"%args.force_proxy if args.force_proxy else ""
         logger.info("Starting proxy server on %s:%s%s", args.bind, args.port, force_proxy_message)
         yield start_server(args.bind, args.port, reactor)
-        logger.info("Successfully started.")
+        logger.info("Successfully started; getting first configuration.")
+        yield updateWPAD()
+        logger.info("Have first configuration.")
     except Exception as e:
         logger.error("Problem starting the server", exc_info=True)
 

--- a/pac4cli/servicemanager.py
+++ b/pac4cli/servicemanager.py
@@ -16,3 +16,5 @@ if 'Linux' == platform.system():
         LogHandler = systemd.journal.JournaldLogHandler
         def notify_ready():
             systemd.daemon.notify(systemd.daemon.Notification.READY)
+    else:
+        raise AssertionError("Something is wrong with the systemd module we imported")


### PR DESCRIPTION
This is a few changes that seemed to make sense to me when I dug deeper into the startup process for #47 and #48. The changes are not needed to fix those issues but seem to make the process better overall.

Specifically:
 * we were sending the `READY=1` signal to systemd, but that was ignored because we didn't have the corresponding configuration in `pac4cli.service`
 * we wouldn't send the READY signal until we'd spoken to NetworkManager, but
    - we can open our own socket before speaking to NetworkManager and send the READY signal as soon as we're listening, and
    - we didn't specify the NetworkManager dependency in `pac4cli.service`

This pull request makes these improvements.