### PR TITLE
Fix duplicate ip for domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+tags
 __pycache__
 env/
 pacparser/

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -55,7 +55,8 @@ def resolve(interface):
         addr.add(ip.exploded)
     except ValueError as e:
         # It is an invalid ip address, let's see if it is a hostname
-        results = socket.getaddrinfo(interface, None, proto=socket.IPPROTO_TCP)
+        # since IPv6 stack is not enabled on all systems, we are looking for IPv4 family only
+        results = socket.getaddrinfo(interface, None, family=socket.AF_INET, proto=socket.IPPROTO_TCP)
         for entry in results:
             ip = entry[4][0]
             ip = ipaddress.ip_address(ip)

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -47,12 +47,13 @@ def start_server(interface, port, reactor):
     servicemanager.notify_ready();
 
 def resolve(interface):
+
     logger.info("resolving interface: %s" % interface)
-    addr = []
+    addr = set()
     try:
         ip = ipaddress.ip_address(interface)
         logger.info("%s => %s" % (interface,ip))
-        addr.append(ip.exploded)
+        addr.add(ip.exploded)
     except ValueError as e:
         # It is an invalid ip address, let's see if it is a hostname
         results = socket.getaddrinfo(interface, None, proto=socket.IPPROTO_TCP)
@@ -60,8 +61,9 @@ def resolve(interface):
             ip = entry[4][0]
             ip = ipaddress.ip_address(ip)
             logger.info("%s => %s" % (interface, ip.exploded))
-            addr.append(ip.exploded)
-    return addr
+            addr.add(ip.exploded)
+
+    return list(addr)
 
 @inlineCallbacks
 def get_possible_configuration_locations():

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -42,7 +42,14 @@ def start_server(interface, port, reactor):
     print( interface_ips )
     for interface_ip in interface_ips:
         logger.info("Binding to interface: '%s'" % interface_ip)
-        yield reactor.listenTCP(port, factory, interface=interface_ip)
+        try:
+            yield reactor.listenTCP(port, factory, interface=interface_ip)
+        except OSError e:
+            # Most likely the most famous reason we will see this log for, 
+            # is that we are trying to bind to an IPv6 interface on a
+            # system that has the IPv6 stack disabled.
+            logger.error("Failed to bind to interface '%s'" % interface_ip)
+            continue
     
     servicemanager.notify_ready();
 
@@ -55,8 +62,7 @@ def resolve(interface):
         addr.add(ip.exploded)
     except ValueError as e:
         # It is an invalid ip address, let's see if it is a hostname
-        # since IPv6 stack is not enabled on all systems, we are looking for IPv4 family only
-        results = socket.getaddrinfo(interface, None, family=socket.AF_INET, proto=socket.IPPROTO_TCP)
+        results = socket.getaddrinfo(interface, None, proto=socket.IPPROTO_TCP)
         for entry in results:
             ip = entry[4][0]
             ip = ipaddress.ip_address(ip)

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -44,7 +44,7 @@ def start_server(interface, port, reactor):
         logger.info("Binding to interface: '%s'" % interface_ip)
         try:
             yield reactor.listenTCP(port, factory, interface=interface_ip)
-        except OSError e:
+        except OSError as e:
             # Most likely the most famous reason we will see this log for, 
             # is that we are trying to bind to an IPv6 interface on a
             # system that has the IPv6 stack disabled.

--- a/pac4cli/__main__.py
+++ b/pac4cli/__main__.py
@@ -47,7 +47,6 @@ def start_server(interface, port, reactor):
     servicemanager.notify_ready();
 
 def resolve(interface):
-
     logger.info("resolving interface: %s" % interface)
     addr = set()
     try:
@@ -62,7 +61,6 @@ def resolve(interface):
             ip = ipaddress.ip_address(ip)
             logger.info("%s => %s" % (interface, ip.exploded))
             addr.add(ip.exploded)
-
     return list(addr)
 
 @inlineCallbacks


### PR DESCRIPTION
If the domain name is mapped to an ip twice or more, the resolved ips for the domain name will contain duplicates. This will make the second call to listen fail on the duplicate ip.

This is easily reproducable by duplicating the `localhost` entry in the local `/etc/hosts`. Then we get the stacktrace from https://github.com/tkluck/pac4cli/pull/49#issuecomment-431586188:

```
INFO [4890]: pac4cli: Starting proxy server on localhost:23129
INFO [4890]: pac4cli: resolving interface: localhost
INFO [4890]: pac4cli: localhost => 127.0.0.1
INFO [4890]: pac4cli: localhost => 127.0.0.1
INFO [4890]: pac4cli: localhost => 0000:0000:0000:0000:0000:0000:0000:0001
['127.0.0.1', '127.0.0.1', '0000:0000:0000:0000:0000:0000:0000:0001']
INFO [4890]: pac4cli: Binding to interface: '127.0.0.1'
INFO [4890]: pac4cli: Binding to interface: '127.0.0.1'
ERROR [4890]: pac4cli: Problem starting the server
<snip>
OSError: [Errno 98] Address already in use
```