### PR TITLE
Run as non-privileged user

### DIFF
--- a/pac4cli.service
+++ b/pac4cli.service
@@ -8,6 +8,7 @@ Type=notify
 ExecStart=/usr/local/bin/pac4cli -p 3128 --systemd --config /etc/pac4cli/pac4cli.config --loglevel warn
 Restart=always
 NotifyAccess=all
+DynamicUser=true
 
 [Install]
 WantedBy=network.target


### PR DESCRIPTION
This systemd feature ensures that anyone potential exploit of pac4cli does not result in root access to the system.