### PR TITLE
Exausting all possible locations for wpad

### DIFF
--- a/pac4cli/wpad.py
+++ b/pac4cli/wpad.py
@@ -130,7 +130,6 @@ class WPAD:
             logger.info("No wpad url specified")
             return None
 
-    @inlineCallbacks
     def get_dns_wpad_urls(self, domains):
         dns_urls = []
         for domain in domains:
@@ -145,17 +144,17 @@ class WPAD:
             #
             # The tld package is using Mozilla's database for top level domains.
             logger.info("Found fqdn: '%s'", domain)
-            tld_res = yield get_tld(domain, as_object=True, fix_protocol=True)
+            tld_res = get_tld(domain, as_object=True, fix_protocol=True)
             logger.debug("tld_res.subdomain: %s", tld_res.subdomain)
             logger.debug("tld_res.fld: %s", tld_res.fld)
             domain_parts = tld_res.subdomain.split('.')
-            for i in range(1, len(domain_parts) + 1):
+            for i in range(1, len(domain_parts)):
                 level_domain = '.'.join(domain_parts[i:])
-                wpad_search_domain = tld_res.fld
-                if level_domain:
-                    wpad_search_domain = '.'.join([level_domain, tld_res.fld])
+                wpad_search_domain = '.'.join([level_domain, tld_res.fld])
                 logger.debug("appending: '%s'", "http://wpad.{}/wpad.dat".format(wpad_search_domain))
                 dns_urls.append("http://wpad.{}/wpad.dat".format(wpad_search_domain))
+            dns_urls.append("http://wpad.{}/wpad.dat".format(tld_res.fld))
+
         return dns_urls
 
     @inlineCallbacks
@@ -179,8 +178,7 @@ class WPAD:
         else:
             logger.info("Trying to get wpad url from NetworkManager domains...")
             domains = yield self.get_FQDNs()
-            dns_urls = yield self.get_dns_wpad_urls(domains)
-            for domain in domains:
-                wpad_urls.append(dns_urls)
+            dns_urls = self.get_dns_wpad_urls(domains)
+            wpad_urls.extend(dns_urls)
 
         return wpad_urls

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ incremental
 twisted
 pyOpenSSL
 service_identity
+tld
 dbus-python; sys_platform == "linux"
 txdbus; sys_platform == "linux"
 systemd; sys_platform == "linux"

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -153,6 +153,21 @@ class TestProxyConfigurations(dbusmock.DBusTestCase):
             fake_proxy_1.proc.kill()
             static_server.proc.kill()
 
+    def test_get_dns_wpad_urls_hostname_only(self):
+        from pac4cli.wpad import WPAD
+        wpad = WPAD(None, None)
+        dns_urls = wpad.get_dns_wpad_urls(["hostname.example.com"])
+        self.assertEqual(len(dns_urls), 1)
+        self.assertEqual(dns_urls[0], "http://wpad.example.com/wpad.dat")
+
+    def test_get_dns_wpad_urls_hostname_and_subdomain(self):
+        from pac4cli.wpad import WPAD
+        wpad = WPAD(None, None)
+        dns_urls = wpad.get_dns_wpad_urls(["hostname.subdomain.example.com"])
+        self.assertEqual(len(dns_urls), 2)
+        self.assertEqual(dns_urls[0], "http://wpad.subdomain.example.com/wpad.dat")
+        self.assertEqual(dns_urls[1], "http://wpad.example.com/wpad.dat")
+
 
 if __name__ == '__main__':
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
If DHCP method failed to find something, and we fallback to the
DNS method, this patch will exaust all possible locations.