### PR TITLE
Urgent! Fix getting potential wpad urls from dns

### DIFF
--- a/pac4cli/wpad.py
+++ b/pac4cli/wpad.py
@@ -147,12 +147,13 @@ class WPAD:
             tld_res = get_tld(domain, as_object=True, fix_protocol=True)
             logger.debug("tld_res.subdomain: %s", tld_res.subdomain)
             logger.debug("tld_res.fld: %s", tld_res.fld)
-            domain_parts = tld_res.subdomain.split('.')
-            for i in range(1, len(domain_parts)):
-                level_domain = '.'.join(domain_parts[i:])
-                wpad_search_domain = '.'.join([level_domain, tld_res.fld])
-                logger.debug("appending: '%s'", "http://wpad.{}/wpad.dat".format(wpad_search_domain))
-                dns_urls.append("http://wpad.{}/wpad.dat".format(wpad_search_domain))
+            domain_parts = [ p for p in tld_res.subdomain.split('.') if p != '' ]
+            print(domain_parts)
+            for i in range(len(domain_parts)):
+                parts = ["wpad"] + domain_parts[i:] + [tld_res.fld]
+                wpad_search_domain = '.'.join(parts)
+                print(wpad_search_domain)
+                dns_urls.append("http://{}/wpad.dat".format(wpad_search_domain))
             dns_urls.append("http://wpad.{}/wpad.dat".format(tld_res.fld))
 
         return dns_urls

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -156,14 +156,14 @@ class TestProxyConfigurations(dbusmock.DBusTestCase):
     def test_get_dns_wpad_urls_hostname_only(self):
         from pac4cli.wpad import WPAD
         wpad = WPAD(None, None)
-        dns_urls = wpad.get_dns_wpad_urls(["hostname.example.com"])
+        dns_urls = wpad.get_dns_wpad_urls(["example.com"])
         self.assertEqual(len(dns_urls), 1)
         self.assertEqual(dns_urls[0], "http://wpad.example.com/wpad.dat")
 
     def test_get_dns_wpad_urls_hostname_and_subdomain(self):
         from pac4cli.wpad import WPAD
         wpad = WPAD(None, None)
-        dns_urls = wpad.get_dns_wpad_urls(["hostname.subdomain.example.com"])
+        dns_urls = wpad.get_dns_wpad_urls(["subdomain.example.com"])
         self.assertEqual(len(dns_urls), 2)
         self.assertEqual(dns_urls[0], "http://wpad.subdomain.example.com/wpad.dat")
         self.assertEqual(dns_urls[1], "http://wpad.example.com/wpad.dat")


### PR DESCRIPTION
Turns out that NetworkManager when asked about the assigned domains
for a given active connection, it returns not the full fqdn of the
host but only the domain part.